### PR TITLE
Added techadvancing ignore tag to research

### DIFF
--- a/Defs/ResearchProjectDefs_Productivity.xml
+++ b/Defs/ResearchProjectDefs_Productivity.xml
@@ -95,7 +95,10 @@
         </researchMods>
         <prerequisites>
             <li>ProductivityV</li>
-        </prerequisites>
+        </prerequisites>                   
+		<tags>
+			<li>ta-ignore</li>
+        </tags>
 		<modExtensions>
 			<li Class="ResearchableStatUpgrades.ModExtension_CompoundBonus">
 				<factor>1.2</factor>


### PR DESCRIPTION
Added the TA-Ignore tag to the repeatable research so that techadvancing will ignore that research when doing its techlevel calculation.
If there are any other repeatable researches, consider also adding it to those.